### PR TITLE
[2.x] Enable/disable CSV translations on config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The package allows configuring some of its features.
 
 return [
     'csv' => [
+        'enabled' => (bool) env('CSV_TRANSLATIONS_ENABLED', true),
         // You might use a custom resolver to get CSV data from elsewhere
         'resolver' => \LaravelCSVTranslations\CSVLocalFileResolver::class,
         'throw_missing_file_exception' => false,

--- a/psalm.xml
+++ b/psalm.xml
@@ -33,6 +33,12 @@
                 <file name="src/CSVLoader.php" />
             </errorLevel>
         </MixedArrayAccess>
+
+        <MixedAssignment>
+            <errorLevel type="suppress">
+                <directory name="src" />
+            </errorLevel>
+        </MixedAssignment>
     </issueHandlers>
 
     <plugins>

--- a/src/CSVLoader.php
+++ b/src/CSVLoader.php
@@ -19,15 +19,16 @@ class CSVLoader extends FileLoader
      */
     public function load($locale, $group, $namespace = null)
     {
-        if ($group === '*' && $namespace === '*' && count($data = $this->getCSVData()) > 0) {
-            return $this->loadCSVLocalizedData($data, $locale);
-        }
-
-        return parent::load($locale, $group, $namespace);
+        return config('lang.csv.enabled', true) === true && $group === '*' && $namespace === '*' && count($data = $this->getCSVData()) > 0
+            ? $this->loadCSVLocalizedData($data, $locale)
+            : parent::load($locale, $group, $namespace);
     }
 
     /**
+     * @param mixed[] $data
      * @return mixed[]
+     *
+     * @throws RuntimeException
      */
     protected function loadCSVLocalizedData(array $data, string $locale): array
     {

--- a/tests/LangTest.php
+++ b/tests/LangTest.php
@@ -62,6 +62,30 @@ final class LangTest extends TestCase
         );
     }
 
+    public function test_translation_when_specifically_enabled(): void
+    {
+        $key = 'greetings.good_morning';
+        $this->app->setLocale('ca');
+
+        $this->app['config']->set('lang.csv.enabled', true);
+        $this->assertEquals(
+            trans($key, ['name' => 'Joan']),
+            'Bon dia, Joan!'
+        );
+    }
+
+    public function test_skips_translation_if_disabled(): void
+    {
+        $key = 'greetings.good_morning';
+        $this->app->setLocale('ca');
+
+        $this->app['config']->set('lang.csv.enabled', false);
+        $this->assertEquals(
+            $key,
+            trans($key, ['name' => 'Joan'])
+        );
+    }
+
     public function test_skips_translation_if_not_found_on_csv_file(): void
     {
         $this->app->setLocale('ca');


### PR DESCRIPTION
When fetching translations from a third party, it might be useful to disable translations when running tests that are not related to translations at all.