### PR TITLE
Raw data access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ junit-logfile.xml
 clover.xml
 composer.lock
 *.cache
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -22,18 +22,24 @@ To use Laravel CSV Translations you will have to **replace the Laravel Translati
 
 ```php
 // config/app.php
-
-// ...
-
 'providers' => [
-
-        // ...
-
-        // Illuminate\Translation\TranslationServiceProvider::class,
-        LaravelCSVTranslations\TranslationServiceProvider::class,
-
-        // ...
+    // ...
+    // Illuminate\Translation\TranslationServiceProvider::class,
+    LaravelCSVTranslations\TranslationServiceProvider::class,
+    // ...
 ],
+```
+
+If your project uses `Illuminate\Support\ServiceProvider`, replace it via the `replace` method.
+
+```php
+// config/app.php
+'providers' => ServiceProvider::defaultProviders()
+    ->replace([
+        \Illuminate\Translation\TranslationServiceProvider::class => \LaravelCSVTranslations\TranslationServiceProvider::class,
+    ])->merge([
+        // ...
+    ])->toArray(),
 ```
 
 To make it work without modifying any configuration, **Create a `lang.csv` file placed in the `lang` folder**.
@@ -135,6 +141,29 @@ class RemoteCSVFileResolver implements CSVResolverInterface
         // Return the CSV formatted data
     }
 }
+```
+
+## Access raw data
+
+Sometimes is useful to access the raw data to list all available translation keys and their values. 
+
+To do so, `CSVLoader` comes with a handy `raw` method.
+
+```php
+// Get the translation loader
+$loader = $this->app['translation.loader'];
+
+// If \LaravelCSVTranslations\TranslationServiceProvider is correctly configured, it should be an instance of CSVLoader 
+$this->assertInstanceOf(\LaravelCSVTranslations\CSVLoader::class, $loader);
+
+$raw = $loader->raw('ca') // Will return an array with raw data
+/*
+[
+  "keys" => "ca",
+  "greetings.good_morning" => "Bon dia, :name!",
+  // ...
+]
+*/
 ```
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ $this->assertInstanceOf(\LaravelCSVTranslations\CSVLoader::class, $loader);
 $raw = $loader->raw('ca') // Will return an array with raw data
 /*
 [
-  "keys" => "ca",
   "greetings.good_morning" => "Bon dia, :name!",
   // ...
 ]

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ class RemoteCSVFileResolver implements CSVResolverInterface
 
 ## Access raw data
 
-Sometimes is useful to access the raw data to list all available translation keys and their values. 
+Sometimes it is useful to access the raw data to list all available translation keys and their values. 
 
 To do so, `CSVLoader` comes with a handy `raw` method.
 

--- a/README.md
+++ b/README.md
@@ -147,16 +147,16 @@ class RemoteCSVFileResolver implements CSVResolverInterface
 
 Sometimes it is useful to access the raw data to list all available translation keys and their values. 
 
-To do so, `CSVLoader` comes with a handy `raw` method.
+To do so, `CSVLoader` comes with a handy `raw` method that returns an associative array with all translation keys and their raw values.
 
 ```php
-// Get the translation loader
+// If TranslationServiceProvider is correctly configured, 'translation.loader' should be an instance of CSVLoader 
+
+/** @var CSVLoader $loader */
 $loader = $this->app['translation.loader'];
 
-// If \LaravelCSVTranslations\TranslationServiceProvider is correctly configured, it should be an instance of CSVLoader 
-$this->assertInstanceOf(\LaravelCSVTranslations\CSVLoader::class, $loader);
-
-$raw = $loader->raw('ca') // Will return an array with raw data
+// Raw method returns an associative array with all translation keys and their raw values
+$raw = $loader->raw('ca') 
 /*
 [
   "greetings.good_morning" => "Bon dia, :name!",

--- a/src/CSVLoader.php
+++ b/src/CSVLoader.php
@@ -97,6 +97,9 @@ class CSVLoader extends FileLoader
         };
     }
 
+    /**
+     * @return mixed[]
+     */
     public function raw(string $locale): array
     {
         return $this->loadCSVLocalizedData($this->getCSVData(), $locale);

--- a/src/CSVLoader.php
+++ b/src/CSVLoader.php
@@ -102,6 +102,12 @@ class CSVLoader extends FileLoader
      */
     public function raw(string $locale): array
     {
-        return $this->loadCSVLocalizedData($this->getCSVData(), $locale);
+        $raw = $this->loadCSVLocalizedData($this->getCSVData(), $locale);
+
+        if (count($raw) > 0) {
+            unset($raw[array_keys($raw)[0]]);
+        }
+
+        return $raw;
     }
 }

--- a/src/CSVLoader.php
+++ b/src/CSVLoader.php
@@ -96,4 +96,9 @@ class CSVLoader extends FileLoader
             default => throw new RuntimeException("Resolver [" . get_debug_type($resolver) . "] must be an instance of " . CSVResolverInterface::class),
         };
     }
+
+    public function raw(string $locale): array
+    {
+        return $this->loadCSVLocalizedData($this->getCSVData(), $locale);
+    }
 }

--- a/tests/LangTest.php
+++ b/tests/LangTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use LaravelCSVTranslations\CSVLoader;
 use LaravelCSVTranslations\CSVResolverInterface;
 use Orchestra\Testbench\TestCase;
 
@@ -160,5 +161,25 @@ final class LangTest extends TestCase
         $this->app['config']->set('lang.csv.resolver', new stdClass());
 
         trans('this test will fail');
+    }
+
+    public function test_access_raw_data()
+    {
+        $loader = $this->app['translation.loader'];
+        $this->assertInstanceOf(CSVLoader::class, $loader);
+
+        $raw = $loader->raw('es');
+        $this->assertTrue(array_key_exists('keys column header content does not matter', $raw) && $raw['keys column header content does not matter'] === 'es');
+        $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Buenos días, :name!');
+        $this->assertTrue(array_key_exists('partial_empty_row', $raw) && $raw['partial_empty_row'] === 'madrid');
+
+        $raw = $loader->raw('ca');
+        $this->assertTrue(array_key_exists('keys column header content does not matter', $raw) && $raw['keys column header content does not matter'] === 'ca');
+        $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Bon dia, :name!');
+        $this->assertTrue(array_key_exists('partial_empty_row', $raw) && $raw['partial_empty_row'] === 'barça');
+
+        $raw = $loader->raw('en');
+        $this->assertTrue(array_key_exists('keys column header content does not matter', $raw) && $raw['keys column header content does not matter'] === 'en');
+        $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Good morning :name!');
     }
 }

--- a/tests/LangTest.php
+++ b/tests/LangTest.php
@@ -181,5 +181,9 @@ final class LangTest extends TestCase
         $raw = $loader->raw('en');
         $this->assertTrue(array_key_exists('keys column header content does not matter', $raw) && $raw['keys column header content does not matter'] === 'en');
         $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Good morning :name!');
+
+        $raw = $loader->raw(uniqid('unknown')); // fallback lang is 'en'
+        $this->assertTrue(array_key_exists('keys column header content does not matter', $raw) && $raw['keys column header content does not matter'] === 'en');
+        $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Good morning :name!');
     }
 }

--- a/tests/LangTest.php
+++ b/tests/LangTest.php
@@ -163,7 +163,7 @@ final class LangTest extends TestCase
         trans('this test will fail');
     }
 
-    public function test_access_raw_data()
+    public function test_access_raw_data(): void
     {
         $loader = $this->app['translation.loader'];
         $this->assertInstanceOf(CSVLoader::class, $loader);

--- a/tests/LangTest.php
+++ b/tests/LangTest.php
@@ -169,21 +169,27 @@ final class LangTest extends TestCase
         $this->assertInstanceOf(CSVLoader::class, $loader);
 
         $raw = $loader->raw('es');
-        $this->assertTrue(array_key_exists('keys column header content does not matter', $raw) && $raw['keys column header content does not matter'] === 'es');
+        $this->assertArrayNotHasKey('keys column header content does not matter', $raw);
         $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Buenos días, :name!');
         $this->assertTrue(array_key_exists('partial_empty_row', $raw) && $raw['partial_empty_row'] === 'madrid');
 
         $raw = $loader->raw('ca');
-        $this->assertTrue(array_key_exists('keys column header content does not matter', $raw) && $raw['keys column header content does not matter'] === 'ca');
+        $this->assertArrayNotHasKey('keys column header content does not matter', $raw);
         $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Bon dia, :name!');
         $this->assertTrue(array_key_exists('partial_empty_row', $raw) && $raw['partial_empty_row'] === 'barça');
 
         $raw = $loader->raw('en');
-        $this->assertTrue(array_key_exists('keys column header content does not matter', $raw) && $raw['keys column header content does not matter'] === 'en');
+        $this->assertArrayNotHasKey('keys column header content does not matter', $raw);
         $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Good morning :name!');
 
         $raw = $loader->raw(uniqid('unknown')); // fallback lang is 'en'
-        $this->assertTrue(array_key_exists('keys column header content does not matter', $raw) && $raw['keys column header content does not matter'] === 'en');
+        $this->assertArrayNotHasKey('keys column header content does not matter', $raw);
         $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Good morning :name!');
+
+        $this->app['config']->set('app.fallback_locale', 'ca');
+        $raw = $loader->raw(uniqid('unknown')); // fallback lang is 'ca'
+        $this->assertArrayNotHasKey('keys column header content does not matter', $raw);
+        $this->assertTrue(array_key_exists('greetings.good_morning', $raw) && $raw['greetings.good_morning'] === 'Bon dia, :name!');
+        $this->assertTrue(array_key_exists('partial_empty_row', $raw) && $raw['partial_empty_row'] === 'barça');
     }
 }


### PR DESCRIPTION
Sometimes it is useful to access the raw data to list all available translation keys and their values.

To do so, `CSVLoader` now comes with a handy `raw` method.